### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,32 @@ var hasOwnProp = Object.prototype.hasOwnProperty;
 
 module.exports = deep;
 
-function deep (obj, path, value) {
+var ILLEGAL_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+function isIllegalKey(key) {
+  return ILLEGAL_KEYS.indexOf(key) !== -1;
+}
+
+function isProtoPath(path) {
+  return Array.isArray(path)
+    ? path.some(isIllegalKey)
+    : typeof path === "string"
+      ? isIllegalKey(path)
+      : false;
+}
+
+function disallowProtoPath(path) {
+  if (isProtoPath(path)) {
+    throw new Error(`Unsafe path encountered: ${path.toString()}`)
+  }
+}
+
+function deep(obj, path, value) {
   if (arguments.length === 3) return set.apply(null, arguments);
   return get.apply(null, arguments);
 }
 
-function get (obj, path) {
+function get(obj, path) {
   var keys = Array.isArray(path) ? path : path.split('.');
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
@@ -20,8 +40,9 @@ function get (obj, path) {
   return obj;
 }
 
-function set (obj, path, value) {
+function set(obj, path, value) {
   var keys = Array.isArray(path) ? path : path.split('.');
+  disallowProtoPath(keys);
   for (var i = 0; i < keys.length - 1; i++) {
     var key = keys[i];
     if (deep.p && !hasOwnProp.call(obj, key)) obj[key] = {};


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution in `propperty`

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-propperty/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *


1. Create the following PoC file:

```
// poc.js
var propperty = require("propperty")
var obj = {}
console.log("Before : " + {}.polluted);
propperty(obj,"__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```

2. Execute the following commands in terminal:

```
npm i propperty # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106890444-55684800-670f-11eb-8e24-7ff31ae78bd9.png)


After:
![image](https://user-images.githubusercontent.com/64132745/106890347-349ff280-670f-11eb-8db2-2bdcd6e98fb9.png)


### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1826
